### PR TITLE
Add missing psycopg2 dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ Flask-Login==0.5.0
 Flask-Migrate==2.5.3
 Flask-Script==2.0.6
 Flask-Dance==3.0.0
+psycopg2-binary==2.8.5
+


### PR DESCRIPTION
Installing binary is easier - you don't have to take care of compiler etc.